### PR TITLE
Bumping up web3 & eth-utils so clean install works.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-web3 == 3.16.4
+web3 == 3.16.5
 eth-abi == 0.5.0
-eth-utils == 0.7.1
+eth-utils == 0.8.1
 eth-testrpc == 1.3.0
 rlp == 0.6.0
 requests == 2.18.4


### PR DESCRIPTION
On a clean system running Python 3.7, with the project freshly cloned and README steps followed, here's the errors you'll receive:

```bash
(venv) pi@raspberrypi:~/arbitrage-keeper $ ./bin/arbitrage-keeper -h
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/local/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/pi/arbitrage-keeper/arbitrage_keeper/arbitrage_keeper.py", line 26, in <module>
    from arbitrage_keeper.conversion import Conversion, OasisTakeConversion, ZrxFillOrderConversion
  File "/home/pi/arbitrage-keeper/arbitrage_keeper/conversion.py", line 18, in <module>
    from pymaker import Address, zrx
  File "/home/pi/arbitrage-keeper/lib/pymaker/pymaker/__init__.py", line 34, in <module>
    from pymaker.util import synchronize
  File "/home/pi/arbitrage-keeper/lib/pymaker/pymaker/util.py", line 22, in <module>
    import eth_keyfile
  File "/home/pi/arbitrage-keeper/venv/lib/python3.7/site-packages/eth_keyfile/__init__.py", line 7, in <module>
    from eth_keyfile.keyfile import (  # noqa: F401
  File "/home/pi/arbitrage-keeper/venv/lib/python3.7/site-packages/eth_keyfile/keyfile.py", line 10, in <module>
    from eth_keys import keys
  File "/home/pi/arbitrage-keeper/venv/lib/python3.7/site-packages/eth_keys/__init__.py", line 15, in <module>
    from .main import (  # noqa: F401
  File "/home/pi/arbitrage-keeper/venv/lib/python3.7/site-packages/eth_keys/main.py", line 3, in <module>
    from eth_keys.datatypes import (
  File "/home/pi/arbitrage-keeper/venv/lib/python3.7/site-packages/eth_keys/datatypes.py", line 38, in <module>
    from eth_keys.validation import (
  File "/home/pi/arbitrage-keeper/venv/lib/python3.7/site-packages/eth_keys/validation.py", line 8, in <module>
    from eth_utils.toolz import curry
ModuleNotFoundError: No module named 'eth_utils.toolz'
```

The `eth-utils` is currently pinned to `0.7.1` and doing a `pip freeze` command shows this information:

```bash
(venv) pi@raspberrypi:~/arbitrage-keeper $ pip freeze
...
eth-utils==0.7.1
...
web3==3.16.4
```

Upgrading the dependencies [based on a Github comment in a separate project](https://github.com/ethereum/populus/issues/450#issuecomment-379576463) led to this being fixed.

```bash
(venv) pi@raspberrypi:~/arbitrage-keeper $ ./bin/arbitrage-keeper -h
usage: arbitrage-keeper [-h] [--rpc-host RPC_HOST] [--rpc-port RPC_PORT]
                        [--rpc-timeout RPC_TIMEOUT] --eth-from ETH_FROM
                        --tub-address TUB_ADDRESS --tap-address TAP_ADDRESS
                        [--exchange-address EXCHANGE_ADDRESS] --oasis-address
                        OASIS_ADDRESS
                        [--oasis-support-address OASIS_SUPPORT_ADDRESS]
                        [--relayer-api-server RELAYER_API_SERVER]
                        [--relayer-per-page RELAYER_PER_PAGE]
                        [--tx-manager TX_MANAGER] [--gas-price GAS_PRICE]
                        --base-token BASE_TOKEN --min-profit MIN_PROFIT
                        --max-engagement MAX_ENGAGEMENT
                        [--max-errors MAX_ERRORS] [--debug]

optional arguments:
  -h, --help            show this help message and exit
  --rpc-host RPC_HOST   JSON-RPC host (default: localhost)
  --rpc-port RPC_PORT   JSON-RPC port (default: 8545)
  --rpc-timeout RPC_TIMEOUT
                        JSON-RPC timeout (in seconds, default: 10)
  --eth-from ETH_FROM   Ethereum account from which to send transactions
  --tub-address TUB_ADDRESS
                        Ethereum address of the Tub contract
  --tap-address TAP_ADDRESS
                        Ethereum address of the Tap contract
  --exchange-address EXCHANGE_ADDRESS
                        Ethereum address of the 0x Exchange contract
  --oasis-address OASIS_ADDRESS
                        Ethereum address of the OasisDEX contract
  --oasis-support-address OASIS_SUPPORT_ADDRESS
                        Ethereum address of the OasisDEX support contract
  --relayer-api-server RELAYER_API_SERVER
                        Address of the 0x Relayer API
  --relayer-per-page RELAYER_PER_PAGE
                        Number of orders to fetch per one page from the 0x
                        Relayer API (default: 100)
  --tx-manager TX_MANAGER
                        Ethereum address of the TxManager contract to use for
                        multi-step arbitrage
  --gas-price GAS_PRICE
                        Gas price in Wei (default: node default)
  --base-token BASE_TOKEN
                        The token all arbitrage sequences will start and end
                        with
  --min-profit MIN_PROFIT
                        Minimum profit (in base token) from one arbitrage
                        operation
  --max-engagement MAX_ENGAGEMENT
                        Maximum engagement (in base token) in one arbitrage
                        operation
  --max-errors MAX_ERRORS
                        Maximum number of allowed errors before the keeper
                        terminates (default: 100)
  --debug               Enable debug output
```

**One thing to note: I haven't actually run the keeper beyond the `help` command, but this got me past the initial stages of installation so thought I would propose it.**