### PR TITLE
Updated pymaker, resolved unit test issues, added eth-key param

### DIFF
--- a/arbitrage_keeper/arbitrage_keeper.py
+++ b/arbitrage_keeper/arbitrage_keeper.py
@@ -30,6 +30,7 @@ from arbitrage_keeper.transfer_formatter import TransferFormatter
 from pymaker import Address
 from pymaker.approval import via_tx_manager, directly
 from pymaker.gas import DefaultGasPrice, FixedGasPrice
+from pymaker.keys import register_keys
 from pymaker.lifecycle import Lifecycle
 from pymaker.numeric import Wad, Ray
 from pymaker.oasis import MatchingMarket
@@ -58,6 +59,9 @@ class ArbitrageKeeper:
 
         parser.add_argument("--eth-from", type=str, required=True,
                             help="Ethereum account from which to send transactions")
+
+        parser.add_argument("--eth-key", type=str, nargs='*',
+                            help="Ethereum private key(s) to use (e.g. 'key_file=aaa.json,pass_file=aaa.pass')")
 
         parser.add_argument("--tub-address", type=str, required=True,
                             help="Ethereum address of the Tub contract")
@@ -106,7 +110,9 @@ class ArbitrageKeeper:
         self.web3 = kwargs['web3'] if 'web3' in kwargs else Web3(HTTPProvider(endpoint_uri=f"http://{self.arguments.rpc_host}:{self.arguments.rpc_port}",
                                                                               request_kwargs={"timeout": self.arguments.rpc_timeout}))
         self.web3.eth.defaultAccount = self.arguments.eth_from
+        register_keys(self.web3, self.arguments.eth_key)
         self.our_address = Address(self.arguments.eth_from)
+
         self.tub = Tub(web3=self.web3, address=Address(self.arguments.tub_address))
         self.tap = Tap(web3=self.web3, address=Address(self.arguments.tap_address))
         self.gem = ERC20Token(web3=self.web3, address=self.tub.gem())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 web3 == 4.8.2
-eth-abi == 0.5.0
-eth-utils == 0.7.1
+eth-abi == 1.3.0
+eth-utils == 1.7.0
 eth-testrpc == 1.3.0
 rlp == 0.6.0
 requests == 2.18.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-web3 == 3.16.4
+web3 == 4.8.2
 eth-abi == 0.5.0
 eth-utils == 0.7.1
 eth-testrpc == 1.3.0

--- a/test.sh
+++ b/test.sh
@@ -12,4 +12,4 @@ TEST_RESULT=$?
 # Cleanup
 pkill -P $GANACHE_PID
 
-exit $TEST_RESULTu
+exit $TEST_RESULT

--- a/test.sh
+++ b/test.sh
@@ -1,3 +1,15 @@
-#!/bin/sh
+#!/bin/bash
 
-PYTHONPATH=$PYTHONPATH:./lib/pymaker py.test --cov=arbitrage_keeper --cov-report=term --cov-append tests/
+# Start ganache; record the PID so it can be cleanly stopped after testing
+./lib/pymaker/ganache.sh &>/dev/null &
+GANACHE_PID=$!
+echo Started ganache as pid $GANACHE_PID
+sleep 2
+
+PYTHONPATH=$PYTHONPATH:./lib/pymaker py.test --cov=arbitrage_keeper --cov-report=term --cov-append tests/ -x
+TEST_RESULT=$?
+
+# Cleanup
+pkill -P $GANACHE_PID
+
+exit $TEST_RESULTu

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,9 +15,16 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import logging
 import pytest
 
 from pymaker.deployment import Deployment
+
+
+# reduce logspew
+logging.getLogger("web3").setLevel(logging.INFO)
+logging.getLogger("urllib3").setLevel(logging.INFO)
+logging.getLogger("asyncio").setLevel(logging.INFO)
 
 
 @pytest.fixture(scope='session')

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -41,4 +41,4 @@ def time_travel_by(web3: Web3, seconds: int):
     assert(isinstance(web3, Web3))
     assert(isinstance(seconds, int))
 
-    web3.providers[0].rpc_methods.testing_timeTravel(web3.eth.getBlock('latest').timestamp + seconds)
+    web3.manager.request_blocking("evm_increaseTime", [seconds])


### PR DESCRIPTION
Blew the dust off of this, allowing users to have Web3 unlock their accounts when using a non-local node.